### PR TITLE
Locking Mechanism

### DIFF
--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -166,17 +166,19 @@ class RandoHandler(RaceHandler):
     async def ex_lock(self, args, message):
         self.state["locked"] = True
         await self.send_message("Seed rolling is now locked.")
-        
+
     @monitor_cmd
     async def ex_unlock(self, args, message):
         self.state["locked"] = False
         await self.send_message("Seed rolling is now unlocked.")
-    
+
     async def ex_rollseed(self, args, message):
         if self.state.get("locked") and not can_monitor(message):
-            await self.send_message("Seed rolling is locked. Only Race Monitors, the Room Creator, and Category Moderators may roll Seeds.")
+            await self.send_message(
+							"Seed rolling is locked. Only Race Monitors, the Room Creator, and Category Moderators may roll Seeds."
+						)
             return
-        
+
         if self.state.get("permalink"):
             permalink = self.state.get("permalink")
             await self.send_message("Seed already rolled!")

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -163,7 +163,20 @@ class RandoHandler(RaceHandler):
         return (self.state.get("race_start_time") - datetime.now()).total_seconds()
 
     @monitor_cmd
+    async def ex_lock(self, args, message):
+        self.state["locked"] = True
+        await self.send_message("Seed rolling is now locked.")
+        
+    @monitor_cmd
+    async def ex_unlock(self, args, message):
+        self.state["locked"] = False
+        await self.send_message("Seed rolling is now unlocked.")
+    
     async def ex_rollseed(self, args, message):
+        if self.state.get("locked") and not can_monitor(message):
+            await self.send_message("Seed rolling is locked. Only Race Monitors, the Room Creator, and Category Moderators may roll Seeds.")
+            return
+        
         if self.state.get("permalink"):
             permalink = self.state.get("permalink")
             await self.send_message("Seed already rolled!")

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -175,8 +175,8 @@ class RandoHandler(RaceHandler):
     async def ex_rollseed(self, args, message):
         if self.state.get("locked") and not can_monitor(message):
             await self.send_message(
-							"Seed rolling is locked. Only Race Monitors, the Room Creator, and Category Moderators may roll Seeds."
-						)
+                "Seed rolling is locked. Only Race Monitors, the Room Creator, and Category Moderators may roll Seeds."
+            )
             return
 
         if self.state.get("permalink"):


### PR DESCRIPTION
Simple change to allow for the locking of seeds to the race monitors, instead of defaulting it to them. Based on sahasrahbot - https://github.com/tcprescott/sahasrahbot/blob/8b7bb8bc01ace8d96a11b5faaafca78d88ce5eb3/alttprbot_racetime/handlers/core.py#L47