### PR TITLE
Implemented an Override

### DIFF
--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -176,9 +176,9 @@ class RandoHandler(RaceHandler):
     async def ex_override(self, args, message):
         self.state["locked"] = True
         self.state["permalink"] = STANDARD_RACE_PERMALINK
-        self.state["permalink_available"] False
+        self.state["permalink_available"] = False
         await self.send_message("Seed is now locked, and the Permalink reset.")
-        
+
     async def ex_rollseed(self, args, message):
         if self.state.get("locked") and not can_monitor(message):
             await self.send_message(

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -173,11 +173,10 @@ class RandoHandler(RaceHandler):
         await self.send_message("Seed rolling is now unlocked.")
 
     @monitor_cmd
-    async def ex_override(self, args, message):
-        self.state["locked"] = True
-        self.state["permalink"] = self.STANDARD_RACE_PERMALINK
+    async def ex_reset(self, args, message):
+        self.state["permalink"] = None
         self.state["permalink_available"] = False
-        await self.send_message("Seed is now locked, and the Permalink reset.")
+        await self.send_message("The Permalink has been reset.")
 
     async def ex_rollseed(self, args, message):
         if self.state.get("locked") and not can_monitor(message):

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -172,6 +172,13 @@ class RandoHandler(RaceHandler):
         self.state["locked"] = False
         await self.send_message("Seed rolling is now unlocked.")
 
+    @monitor_cmd
+    async def ex_override(self, args, message):
+        self.state["locked"] = True
+        self.state["permalink"] = STANDARD_RACE_PERMALINK
+        self.state["permalink_available"] False
+        await self.send_message("Seed is now locked, and the Permalink reset.")
+        
     async def ex_rollseed(self, args, message):
         if self.state.get("locked") and not can_monitor(message):
             await self.send_message(

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -175,7 +175,7 @@ class RandoHandler(RaceHandler):
     @monitor_cmd
     async def ex_override(self, args, message):
         self.state["locked"] = True
-        self.state["permalink"] = STANDARD_RACE_PERMALINK
+        self.state["permalink"] = self.STANDARD_RACE_PERMALINK
         self.state["permalink_available"] = False
         await self.send_message("Seed is now locked, and the Permalink reset.")
 


### PR DESCRIPTION
In cases where the wrong seed is rolling (Whoops) this would allow a state reset without leaving the race room. This wouldn't work for Spoiler Log seeds, and is locked to Race Monitors.