### PR TITLE
Updated Racetime.gg Information

### DIFF
--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -48,6 +48,7 @@ class RandoHandler(RaceHandler):
                         await self.send_message("You have 15 minutes until the race starts!")
                         permalink = self.state.get("permalink")
                         await self.send_message(f"Permalink: {permalink}")
+                        await self.set_raceinfo(f" - {permalink}")
                         self.state["permalink_available"] = True
 
                     if not self.state.get("10_warning_sent") and seconds_remaining < 600:  # 10 minutes

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -206,6 +206,7 @@ class RandoHandler(RaceHandler):
         self.state["permalink_available"] = True
 
         await self.send_message(f"Permalink: {permalink}")
+        await self.set_raceinfo(f" - {permalink}")
 
     async def ex_startspoilerlograce(self, args, message):
         if self.state.get("locked") and not can_monitor(message):


### PR DESCRIPTION
Appends the end of the raceroom with the permalink. At some point it should also Prefix it with the style of race. 
Examples would be 
Standard : Permalink
Spoiler : Permalink
Fun : Permalink
Further Changes to !reset would be required, else we would get "Example Title - Permalink - Other Permalink"
Potentially could use str.split("-") on the title and removing the last element?