### PR TITLE
Better Case handling, minor changes.

### DIFF
--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -30,7 +30,10 @@ class RandoHandler(RaceHandler):
                 if self.state.get("spoiler_log_seed_rolled"):
                     seconds_remaining = self.seconds_remaining()
 
-                    if seconds_remaining <= self.state.get("next_ten_minute_warning") and seconds_remaining > 550: #40/30/20/10 Minutes
+                    if (
+                        seconds_remaining <= self.state.get("next_ten_minute_warning") 
+                        and seconds_remaining > 550:  # 40/30/20/10 Minutes
+                    ):
                         if self.state.get("next_ten_minute_warning") == 600:
                             await self.send_message("You have 10 minutes until the race starts!")
                             await self.send_message("Please start your stream if you haven't done so already!")

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -33,7 +33,7 @@ class RandoHandler(RaceHandler):
                     if (
                         seconds_remaining <= self.state.get("next_ten_minute_warning")
                         and seconds_remaining > 550  # 40/30/20/10 Minutes
-                    ): 
+                    ):
                         if self.state.get("next_ten_minute_warning") == 600:
                             await self.send_message("You have 10 minutes until the race starts!")
                             await self.send_message("Please start your stream if you haven't done so already!")

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -31,9 +31,9 @@ class RandoHandler(RaceHandler):
                     seconds_remaining = self.seconds_remaining()
 
                     if (
-                        seconds_remaining <= self.state.get("next_ten_minute_warning") 
-                        and seconds_remaining > 550:  # 40/30/20/10 Minutes
-                    ):
+                        seconds_remaining <= self.state.get("next_ten_minute_warning")
+                        and seconds_remaining > 550  # 40/30/20/10 Minutes
+                    ): 
                         if self.state.get("next_ten_minute_warning") == 600:
                             await self.send_message("You have 10 minutes until the race starts!")
                             await self.send_message("Please start your stream if you haven't done so already!")


### PR DESCRIPTION
Miscellaneous Changes
-Adjusted line 189, since `if self.state.get("permalink")` doesn't make sense in the context.
-Moved `self.loop.create_task(self.handle_scheduled_tasks())` from `begin()` to after the creation of the Spoiler log in `start_spoiler_log_race()`. No reason to have the loop running before the timer starts, and in Standard Race rooms. We also set `self.loop_ended = False` before calling it, in case someone used `!reset` which uses the `self.close_handler()` in order to kill the loop externally. *I am unsure if this works correctly.*
 
Time Warnings
-Implemented the state `next_ten_minute_warning` which helped condense the 40/30/20/10 warnings into one section. Still need to figure out how to have better handling for 15/5/1.

-Reset Changes
Reset now unbans tingle tuner, clears `permalink_available` which means when you run either `!rollseed` or `!startspoilerlograce` it behaves as expected. it also resets all the parts of `self.state` that would affect changing aspects of the room, or which are no longer needed.