### PR TITLE
Add command to set planning time for spoiler log races

### DIFF
--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -188,6 +188,10 @@ class RandoHandler(RaceHandler):
         await self.send_message(msg)
 
     async def ex_setplanningtime(self, args, message):
+        if self.state["spoiler_log_seed_rolled"]:
+            await self.send_message("Planning has already started!")
+            return
+
         if len(args) == 0:
             await self.send_message("Please specify planning time (in minutes).")
 

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -195,7 +195,7 @@ class RandoHandler(RaceHandler):
 
         try:
             self.state["planning_time"] = max(self.MINIMUM_PLANNING_TIME, int(planning_time))
-            await self.send_message(f"Planning time set to {planning_time} minutes.")
+            await self.send_message(f"Planning time set to {self.state["planning_time"]} minutes.")
         except (TypeError, ValueError):
             await self.send_message(f"{planning_time} is not a valid time.")
 

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -194,6 +194,7 @@ class RandoHandler(RaceHandler):
 
         if len(args) == 0:
             await self.send_message("Please specify planning time (in minutes).")
+            return
 
         planning_time = args[0]
 

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -200,7 +200,7 @@ class RandoHandler(RaceHandler):
 
         try:
             self.state["planning_time"] = max(self.MINIMUM_PLANNING_TIME, int(planning_time))
-            await self.send_message(f"Planning time set to {self.state["planning_time"]} minutes.")
+            await self.send_message(f"Planning time set to {self.state['planning_time']} minutes.")
         except (TypeError, ValueError):
             await self.send_message(f"{planning_time} is not a valid time.")
 

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -196,7 +196,7 @@ class RandoHandler(RaceHandler):
         try:
             self.state["planning_time"] = max(self.MINIMUM_PLANNING_TIME, int(planning_time))
             await self.send_message(f"Planning time set to {planning_time} minutes.")
-        except TypeError:
+        except (TypeError, ValueError):
             await self.send_message(f"{planning_time} is not a valid time.")
 
     async def ex_rollseed(self, args, message):

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -187,7 +187,6 @@ class RandoHandler(RaceHandler):
         self.room_setup()
         await self.send_message(msg)
 
-    @monitor_cmd
     async def ex_setplanningtime(self, args, message):
         if len(args) == 0:
             await self.send_message("Please specify planning time (in minutes).")


### PR DESCRIPTION
This PR adds the ability to set the planning time for spoiler log races. The command is `!setplanningtime`. By default, the planning time is 50 minutes. The bot enforces that the minimum planning time is 20 minutes to distribute permalinks properly. Resetting the bot also resets the planning time to 50 minutes. A warning message will appear every ten-minute mark until the race begins.