### PR TITLE
Add command to roll seeds on dev build

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-exclude = wwrando
+exclude = wwrando, wwrando-dev-tanjo3
 max-line-length = 120
 extend-ignore = E203, W503

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
             sudo rm -r tww-rando-bot || true
             git clone --recursive https://github.com/wooferzfg/tww-rando-bot.git
             echo "${{ secrets.WWRANDO_SEED_KEY }}" > tww-rando-bot/wwrando/keys/seed_key.py
+            echo "${{ secrets.WWRANDO_DEV_TANJO3_SEED_KEY }}" > tww-rando-bot/wwrando-dev-tanjo3/keys/seed_key.py
             cd tww-rando-bot
             docker-compose build --no-cache
             export GITHUB_TOKEN=${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "wwrando"]
 	path = wwrando
 	url = https://github.com/wooferzfg/wwrando.git
+[submodule "wwrando-dev-tanjo3"]
+	path = wwrando-dev-tanjo3
+	url = https://github.com/tanjo3/wwrando.git
+	branch = dev-build-no-ui

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /tww-rando-bot
 ENV QT_QPA_PLATFORM=offscreen
 
 RUN apt-get update && apt-get install -y \
+  libegl1 \
   libgl1-mesa-glx \
   libxkbcommon-x11-0 \
   libdbus-1-3
@@ -12,5 +13,11 @@ RUN apt-get update && apt-get install -y \
 COPY . .
 
 RUN cd wwrando && pip install -r requirements.txt
+
+RUN pip install -e .
+
+RUN cd ..
+
+RUN cd wwrando-dev-tanjo3 && pip install -r requirements.txt
 
 RUN pip install -e .

--- a/randobot/constants.py
+++ b/randobot/constants.py
@@ -58,4 +58,12 @@ SPOILER_LOG_DEFAULT = ["preset-a", "preset-b", "preset-c", "preset-d", "preset-e
 DEFAULT_PLANNING_TIME = 60
 MINIMUM_PLANNING_TIME = 20
 
+DEV_PERMALINKS = OrderedDict([
+    ("default", "eJwz1LPUMzSIT0ktY3BkYGdkZigwYXjAWMDAKMUABg0MJAAAZlcFog=="),
+])
+
+DEV_DEFAULT = ["default"]
+DEV_VERSION = "1.9.10_dev"
+DEV_DOWNLOAD = "https://github.com/tanjo3/wwrando/releases"
+
 BANNABLE_PRESETS = SPOILER_LOG_DEFAULT + RANDOM_STARTING_ITEM_PRESETS

--- a/randobot/constants.py
+++ b/randobot/constants.py
@@ -9,6 +9,7 @@ STANDARD_PERMALINKS = OrderedDict([
 ])
 
 STANDARD_DEFAULT = ["s4"]
+STANDARD_PATH = "wwrando"
 
 SPOILER_LOG_PERMALINKS = OrderedDict([
     ("preset-a",  "MS45LjAAQQA3AyYCD1DAAgAAAAAAAAAA"),
@@ -39,6 +40,7 @@ DEV_PERMALINKS = OrderedDict([
 ])
 
 DEV_DEFAULT = ["default"]
+DEV_PATH = "wwrando-dev-tanjo3"
 DEV_VERSION = "1.9.10_dev"
 DEV_DOWNLOAD = "https://github.com/tanjo3/wwrando/releases"
 

--- a/randobot/generator.py
+++ b/randobot/generator.py
@@ -11,13 +11,13 @@ class Generator:
     def __init__(self, github_token):
         self.github_token = github_token
 
-    def generate_seed(self, permalink, username, generate_spoiler_log):
+    def generate_seed(self, permalink, username, generate_spoiler_log, randomizer_path="wwrando"):
         trimmed_name = re.sub(r'\W+', '', username)[:12]
         random_suffix = shortuuid.ShortUUID().random(length=10)
         seed_name = f"{trimmed_name}{random_suffix}"
         file_name = "".join(random.choice(string.digits) for _ in range(6))
 
-        os.system(f"python wwrando/wwrando.py -seed={seed_name} -permalink={permalink}")
+        os.system(f"python {randomizer_path}/wwrando.py -seed={seed_name} -permalink={permalink}")
 
         permalink_file_name = f"permalink_{seed_name}.txt"
         permalink_file = open(permalink_file_name, "r")

--- a/randobot/generator.py
+++ b/randobot/generator.py
@@ -11,7 +11,7 @@ class Generator:
     def __init__(self, github_token):
         self.github_token = github_token
 
-    def generate_seed(self, permalink, username, generate_spoiler_log, randomizer_path="wwrando"):
+    def generate_seed(self, randomizer_path, permalink, username, generate_spoiler_log):
         trimmed_name = re.sub(r'\W+', '', username)[:12]
         random_suffix = shortuuid.ShortUUID().random(length=10)
         seed_name = f"{trimmed_name}{random_suffix}"

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -401,7 +401,7 @@ class RandoHandler(RaceHandler):
         await self.send_message(f"You have {planning_time} minutes to prepare your route!")
 
         spoiler_log_url = self.state["spoiler_log_url"]
-        if self.state.get("spoiler_log_url"):
+        if spoiler_log_url:
             await self.send_message(f"Spoiler Log: {spoiler_log_url}")
             self.state["spoiler_log_available"] = True
             await self.print_example_permalink()

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -244,22 +244,7 @@ class RandoHandler(RaceHandler):
             await self.send_message(f"{planning_time} is not a valid time.")
 
     async def ex_rollseed(self, args, message):
-        if self.state.get("locked") and not can_monitor(message):
-            await self.send_message(
-                "Seed rolling is locked. Only the creator of this room, a race monitor, or a moderator can roll a seed."
-            )
-            return
-
-        if self.state.get("spoiler_log_seed_rolled"):
-            await self.send_message("Seed rolling is disabled in spoiler log races!")
-            return
-
-        if self.state.get("permalink_available"):
-            permalink = self.state.get("permalink")
-            seed_hash = self.state.get("seed_hash")
-            await self.send_message("Seed already rolled!")
-            await self.send_message(f"Permalink: {permalink}")
-            await self.send_message(f"Seed Hash: {seed_hash}")
+        if not await self.can_roll_standard_seed(message):
             return
 
         await self.send_message("Rolling seed...")
@@ -272,41 +257,12 @@ class RandoHandler(RaceHandler):
 
         username = message.get('user', {}).get('name')
         generated_seed = self.generator.generate_seed("wwrando", settings_permalink, username, False)
-        permalink = generated_seed.get("permalink")
-        seed_hash = generated_seed.get("seed_hash")
-
-        self.logger.info(permalink)
-
-        self.state["example_permalink"] = settings_permalink
-        self.state["permalink"] = permalink
-        self.state["permalink_available"] = True
-        self.state["seed_hash"] = seed_hash
-
-        await self.send_message(f"Permalink: {permalink}")
-        await self.send_message(f"Seed Hash: {seed_hash}")
-
-        race_info = f"{permalink} | Seed Hash: {seed_hash}"
-        await self.set_raceinfo(race_info, False, False)
+        await self.update_race_room_with_generated_seed(settings_permalink, generated_seed, False)
 
     async def ex_rolldevseed(self, args, message):
-        if self.state.get("locked") and not can_monitor(message):
-            await self.send_message(
-                "Seed rolling is locked. Only the creator of this room, a race monitor, or a moderator can roll a seed."
-            )
+        if not await self.can_roll_standard_seed(message):
             return
-
-        if self.state.get("spoiler_log_seed_rolled"):
-            await self.send_message("Seed rolling is disabled in spoiler log races!")
-            return
-
-        if self.state.get("permalink_available"):
-            permalink = self.state.get("permalink")
-            seed_hash = self.state.get("seed_hash")
-            await self.send_message("Seed already rolled!")
-            await self.send_message(f"Permalink: {permalink}")
-            await self.send_message(f"Seed Hash: {seed_hash}")
-            return
-
+        
         await self.send_message("Rolling seed...")
 
         settings_permalink = await self.choose_permalink(
@@ -317,6 +273,35 @@ class RandoHandler(RaceHandler):
 
         username = message.get('user', {}).get('name')
         generated_seed = self.generator.generate_seed("wwrando-dev-tanjo3", settings_permalink, username, False)
+        await self.update_race_room_with_generated_seed(settings_permalink, generated_seed, False)
+
+        await self.send_message(
+            f"Please note that this seed has been rolled on the {constants.DEV_VERSION} version of the randomizer. "
+            f"You can download it here: {constants.DEV_DOWNLOAD}"
+        )
+
+    async def can_roll_standard_seed(self, message):
+        if self.state.get("locked") and not can_monitor(message):
+            await self.send_message(
+                "Seed rolling is locked. Only the creator of this room, a race monitor, or a moderator can roll a seed."
+            )
+            return False
+
+        if self.state.get("spoiler_log_seed_rolled"):
+            await self.send_message("Seed rolling is disabled in spoiler log races!")
+            return False
+
+        if self.state.get("permalink_available"):
+            permalink = self.state.get("permalink")
+            seed_hash = self.state.get("seed_hash")
+            await self.send_message("Seed already rolled!")
+            await self.send_message(f"Permalink: {permalink}")
+            await self.send_message(f"Seed Hash: {seed_hash}")
+            return False
+        
+        return True
+    
+    async def update_race_room_with_generated_seed(self, settings_permalink, generated_seed, is_spoiler_log):
         permalink = generated_seed.get("permalink")
         seed_hash = generated_seed.get("seed_hash")
 
@@ -324,18 +309,27 @@ class RandoHandler(RaceHandler):
 
         self.state["example_permalink"] = settings_permalink
         self.state["permalink"] = permalink
-        self.state["permalink_available"] = True
         self.state["seed_hash"] = seed_hash
 
-        await self.send_message(f"Permalink: {permalink}")
-        await self.send_message(f"Seed Hash: {seed_hash}")
-        await self.send_message(
-            f"Please note that this seed has been rolled on the {constants.DEV_VERSION} version of the randomizer. "
-            "You can download it here: {constants.DEV_DOWNLOAD}"
-        )
+        if is_spoiler_log:
+            spoiler_log_url = generated_seed.get("spoiler_log_url")
+            file_name = generated_seed.get("file_name")
 
-        race_info = f"{permalink} | Seed Hash: {seed_hash}"
-        await self.set_raceinfo(race_info, False, False)
+            self.logger.info(spoiler_log_url)
+            self.logger.info(file_name)
+
+            self.state["spoiler_log_url"] = spoiler_log_url
+            self.state["file_name"] = file_name
+
+            await self.send_message("Seed rolled!")
+        else:
+            self.state["permalink_available"] = True
+
+            await self.send_message(f"Permalink: {permalink}")
+            await self.send_message(f"Seed Hash: {seed_hash}")
+
+            race_info = f"{permalink} | Seed Hash: {seed_hash}"
+            await self.set_raceinfo(race_info, False, False)
 
     async def ex_startspoilerlogtimer(self, args, message):
         if self.state.get("locked") and not can_monitor(message):
@@ -379,22 +373,7 @@ class RandoHandler(RaceHandler):
             await self.send_message("Rolling seed...")
 
             generated_seed = self.generator.generate_seed("wwrando", settings_permalink, username, True)
-            spoiler_log_url = generated_seed.get("spoiler_log_url")
-            permalink = generated_seed.get("permalink")
-            seed_hash = generated_seed.get("seed_hash")
-            file_name = generated_seed.get("file_name")
-
-            self.logger.info(spoiler_log_url)
-            self.logger.info(permalink)
-            self.logger.info(file_name)
-
-            self.state["example_permalink"] = settings_permalink
-            self.state["spoiler_log_url"] = spoiler_log_url
-            self.state["permalink"] = permalink
-            self.state["seed_hash"] = seed_hash
-            self.state["file_name"] = file_name
-
-            await self.send_message("Seed rolled!")
+            await self.update_race_room_with_generated_seed(settings_permalink, generated_seed, True)
 
         planning_time = self.state.get("planning_time")
 
@@ -421,6 +400,7 @@ class RandoHandler(RaceHandler):
 
         await self.send_message(f"You have {planning_time} minutes to prepare your route!")
 
+        spoiler_log_url = self.state["spoiler_log_url"]
         if self.state.get("spoiler_log_url"):
             await self.send_message(f"Spoiler Log: {spoiler_log_url}")
             self.state["spoiler_log_available"] = True

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -271,7 +271,7 @@ class RandoHandler(RaceHandler):
         )
 
         username = message.get('user', {}).get('name')
-        generated_seed = self.generator.generate_seed(settings_permalink, username, False)
+        generated_seed = self.generator.generate_seed("wwrando", settings_permalink, username, False)
         permalink = generated_seed.get("permalink")
         seed_hash = generated_seed.get("seed_hash")
 
@@ -316,7 +316,7 @@ class RandoHandler(RaceHandler):
         )
 
         username = message.get('user', {}).get('name')
-        generated_seed = self.generator.generate_seed(settings_permalink, username, False, randomizer_path="wwrando-dev-tanjo3")
+        generated_seed = self.generator.generate_seed("wwrando-dev-tanjo3", settings_permalink, username, False)
         permalink = generated_seed.get("permalink")
         seed_hash = generated_seed.get("seed_hash")
 
@@ -329,7 +329,10 @@ class RandoHandler(RaceHandler):
 
         await self.send_message(f"Permalink: {permalink}")
         await self.send_message(f"Seed Hash: {seed_hash}")
-        await self.send_message(f"Please note that this seed has been rolled on the {constants.DEV_VERSION} version of the randomizer. You can download it here: {constants.DEV_DOWNLOAD}")
+        await self.send_message(
+            f"Please note that this seed has been rolled on the {constants.DEV_VERSION} version of the randomizer. "
+            "You can download it here: {constants.DEV_DOWNLOAD}"
+        )
 
         race_info = f"{permalink} | Seed Hash: {seed_hash}"
         await self.set_raceinfo(race_info, False, False)
@@ -375,7 +378,7 @@ class RandoHandler(RaceHandler):
         if settings_permalink:
             await self.send_message("Rolling seed...")
 
-            generated_seed = self.generator.generate_seed(settings_permalink, username, True)
+            generated_seed = self.generator.generate_seed("wwrando", settings_permalink, username, True)
             spoiler_log_url = generated_seed.get("spoiler_log_url")
             permalink = generated_seed.get("permalink")
             seed_hash = generated_seed.get("seed_hash")

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -256,7 +256,7 @@ class RandoHandler(RaceHandler):
         )
 
         username = message.get('user', {}).get('name')
-        generated_seed = self.generator.generate_seed("wwrando", settings_permalink, username, False)
+        generated_seed = self.generator.generate_seed(constants.STANDARD_PATH, settings_permalink, username, False)
         await self.update_race_room_with_generated_seed(settings_permalink, generated_seed, False)
 
     async def ex_rolldevseed(self, args, message):
@@ -272,7 +272,7 @@ class RandoHandler(RaceHandler):
         )
 
         username = message.get('user', {}).get('name')
-        generated_seed = self.generator.generate_seed("wwrando-dev-tanjo3", settings_permalink, username, False)
+        generated_seed = self.generator.generate_seed(constants.DEV_PATH, settings_permalink, username, False)
         await self.update_race_room_with_generated_seed(settings_permalink, generated_seed, False)
 
         await self.send_message(
@@ -372,7 +372,7 @@ class RandoHandler(RaceHandler):
         if settings_permalink:
             await self.send_message("Rolling seed...")
 
-            generated_seed = self.generator.generate_seed("wwrando", settings_permalink, username, True)
+            generated_seed = self.generator.generate_seed(constants.STANDARD_PATH, settings_permalink, username, True)
             await self.update_race_room_with_generated_seed(settings_permalink, generated_seed, True)
 
         planning_time = self.state.get("planning_time")

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -262,7 +262,7 @@ class RandoHandler(RaceHandler):
     async def ex_rolldevseed(self, args, message):
         if not await self.can_roll_standard_seed(message):
             return
-        
+
         await self.send_message("Rolling seed...")
 
         settings_permalink = await self.choose_permalink(
@@ -298,9 +298,9 @@ class RandoHandler(RaceHandler):
             await self.send_message(f"Permalink: {permalink}")
             await self.send_message(f"Seed Hash: {seed_hash}")
             return False
-        
+
         return True
-    
+
     async def update_race_room_with_generated_seed(self, settings_permalink, generated_seed, is_spoiler_log):
         permalink = generated_seed.get("permalink")
         seed_hash = generated_seed.get("seed_hash")


### PR DESCRIPTION
This PR adds the `!rolldevseed` command which rolls a seed using the 1.9.10_dev version of the dev build.

The usage of the `!rolldevseed` command is the same as with the `!rollseed` command, with the main difference being which build of the randomizer to bot uses. I also added a little message after the seed has been rolled to remind runners that they need to be using the 1.9.10_dev build.

For default settings, I just used the current default settings of the build. I considered adding the options currently up for voting for the S5 tournament. However, with random starting item and hint distributions, there'd be too many options to include, in my opinion. Plus, this testing period will not be for much longer anyway.