### PR TITLE
Add `!randomsettings`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-exclude = wwrando, wwrando-dev-tanjo3, wwrando-s5-tournament
+exclude = wwrando, wwrando-dev-tanjo3, wwrando-random-settings, wwrando-s5-tournament
 max-line-length = 120
 extend-ignore = E203, W503

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,6 +5,10 @@
 	path = wwrando-dev-tanjo3
 	url = https://github.com/tanjo3/wwrando.git
 	branch = dev-build-no-ui
+[submodule "wwrando-random-settings"]
+	path = wwrando-random-settings
+	url = https://github.com/tanjo3/wwrando.git
+	branch = random-settings
 [submodule "wwrando-s5-tournament"]
 	path = wwrando-s5-tournament
 	url = https://github.com/tanjo3/wwrando.git

--- a/randobot/constants.py
+++ b/randobot/constants.py
@@ -54,7 +54,7 @@ DEV_PATH = "wwrando-dev-tanjo3"
 DEV_VERSION = "1.9.10_dev"
 DEV_DOWNLOAD = "https://github.com/tanjo3/wwrando/releases"
 
-RS_PATH = "wwrando-dev-tanjo3"
+RS_PATH = "wwrando-random-settings"
 RS_VERSION = "v1.1"
 RS_DOWNLOAD = "https://github.com/tanjo3/wwrando/releases/tag/RS_v1.1"
 RS_TRACKER = "https://tww-rando-tracker-rsl.herokuapp.com/"

--- a/randobot/constants.py
+++ b/randobot/constants.py
@@ -1,4 +1,14 @@
 from collections import OrderedDict
+from enum import Enum
+
+
+class SeedType(Enum):
+    STANDARD = 1
+    SPOILER_LOG = 2
+    DEV = 3
+    RANDOM_SETTINGS = 4
+    S5 = 5
+
 
 STANDARD_PERMALINKS = OrderedDict([
     ("s4",        "MS45LjAAQQAFCyIAD3DAAgAAAAAAAQAA"),

--- a/randobot/constants.py
+++ b/randobot/constants.py
@@ -44,6 +44,11 @@ DEV_PATH = "wwrando-dev-tanjo3"
 DEV_VERSION = "1.9.10_dev"
 DEV_DOWNLOAD = "https://github.com/tanjo3/wwrando/releases"
 
+RS_PATH = "wwrando-dev-tanjo3"
+RS_VERSION = "v1.1"
+RS_DOWNLOAD = "https://github.com/tanjo3/wwrando/releases/tag/RS_v1.1"
+RS_TRACKER = "https://tww-rando-tracker-rsl.herokuapp.com/"
+
 S5_PERMALINKS = OrderedDict([
     ("default", "UzUuMABTNQAVAyIAJ3l8gAEWAIx7AIE+AAAA"),
 ])

--- a/randobot/generator.py
+++ b/randobot/generator.py
@@ -17,7 +17,7 @@ class Generator:
         seed_name = f"{trimmed_name}{random_suffix}"
         file_name = "".join(random.choice(string.digits) for _ in range(6))
 
-        os.system(f"python {randomizer_path}/wwrando.py -seed={seed_name} -permalink={permalink}")
+        os.system(f"python {randomizer_path}/wwrando.py -noui -seed={seed_name} -permalink={permalink}")
 
         permalink_file_name = f"permalink_{seed_name}.txt"
         permalink_file = open(permalink_file_name, "r")

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -291,6 +291,22 @@ class RandoHandler(RaceHandler):
             f"You can download it here: {constants.DEV_DOWNLOAD}"
         )
 
+    async def ex_randomsettings(self, args, message):
+        if not await self.can_roll_standard_seed(message):
+            return
+
+        await self.send_message("Rolling seed...")
+
+        username = message.get('user', {}).get('name')
+        generated_seed = self.generator.generate_seed(constants.RS_PATH, username, username, False)
+        await self.update_race_room_with_generated_seed(None, generated_seed, False)
+
+        await self.send_message(
+            f"Please note that this seed has been rolled on the {constants.RS_VERSION} version of the randomizer. "
+            f"Download: {constants.RS_DOWNLOAD} "
+            f"Tracker: {constants.RS_TRACKER}"
+        )
+
     async def ex_s5(self, args, message):
         if not await self.can_roll_standard_seed(message):
             return


### PR DESCRIPTION
This PR adds the command `!randomsettings`, which rolls a seed with random settings specified by the random settings build.

Since the concept of a permalink doesn't make sense with random settings (only the seed name is shared for races), this PR also introduces a new enum `SeedType` to execute the correct behavior when the race room is updated. In the case of random settings, the `permalink` remain set to the default `None`, and the seed name is output in its place.

Finally, we use the `-noui` flag to ensure that the bot runs the randomizer without UI. For the no-ui branches currently employed, the flag has no effect. However, the random settings branch used by the bot to roll seeds has modified behavior so that the `-noui` functions correctly. In the future, no-ui branches should be deprecated in favor of branches that properly implement `-noui` functionality.