### PR TITLE
Update RS tracker link

### DIFF
--- a/randobot/constants.py
+++ b/randobot/constants.py
@@ -57,7 +57,7 @@ DEV_DOWNLOAD = "https://github.com/tanjo3/wwrando/releases"
 RS_PATH = "wwrando-random-settings"
 RS_VERSION = "v1.1"
 RS_DOWNLOAD = "https://github.com/tanjo3/wwrando/releases/tag/RS_v1.1"
-RS_TRACKER = "https://tww-rando-tracker-rsl.herokuapp.com/"
+RS_TRACKER = "https://jaysc.github.io/tww-rando-tracker-rs/"
 
 S5_PERMALINKS = OrderedDict([
     ("default", "UzUuMABTNQAVAyIAJ3l8gAEWAIx7AIE+AAAA"),


### PR DESCRIPTION
The old tracker link pointed to a Heroku app which has usage limits. The new tracker is hosted on GitHub Pages instead.