### PR TITLE
Unlock RSL spoiler log after race

### DIFF
--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -124,16 +124,6 @@ class RandoHandler(RaceHandler):
                         self.state["last_break_time"] = self.state.get("last_break_time") + timedelta(
                             0, 0, 0, 0, break_interval
                         )
-
-                if self.data.get("status").get("value") == "finished" and not self.state.get(
-                    "rsl_spoiler_log_unlocked"
-                ):
-                    spoiler_log_url = self.state.get("spoiler_log_url")
-                    await self.send_message(
-                        f"The race is now finished. The spoiler log can be found here: {spoiler_log_url}"
-                    )
-                    self.state["rsl_spoiler_log_unlocked"] = True
-
             except Exception:
                 pass
             finally:
@@ -166,6 +156,13 @@ class RandoHandler(RaceHandler):
                 )
 
             self.state["finished_entrants"] = finished_entrants
+
+        if self.data.get("status").get("value") == "finished" and not self.state.get("rsl_spoiler_log_unlocked"):
+            spoiler_log_url = self.state.get("spoiler_log_url")
+            await self.send_message(
+                f"The race is now finished. The spoiler log can be found here: {spoiler_log_url}"
+            )
+            self.state["rsl_spoiler_log_unlocked"] = True
 
     async def ex_spoilerlogurl(self, args, message):
         spoiler_log_url = self.state.get("spoiler_log_url")

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -47,7 +47,8 @@ class RandoHandler(RaceHandler):
         self.state["5_warning_sent"] = False
         self.state["1_warning_sent"] = False
         self.state["spoiler_log_race_started"] = False
-        self.state["rsl_spoiler_log_unlocked"] = False
+        self.state["random_settings_seed_rolled"] = False
+        self.state["random_settings_spoiler_log_unlocked"] = False
 
     def close_handler(self):
         self.loop_ended = True
@@ -157,12 +158,14 @@ class RandoHandler(RaceHandler):
 
             self.state["finished_entrants"] = finished_entrants
 
-        if self.data.get("status").get("value") == "finished" and not self.state.get("rsl_spoiler_log_unlocked"):
+        if (
+            self.state.get("random_settings_seed_rolled")
+            and not self.state.get("random_settings_spoiler_log_unlocked")
+            and self.data.get("status").get("value") == "finished"
+        ):
             spoiler_log_url = self.state.get("spoiler_log_url")
-            await self.send_message(
-                f"The race is now finished. The spoiler log can be found here: {spoiler_log_url}"
-            )
-            self.state["rsl_spoiler_log_unlocked"] = True
+            await self.send_message(f"The race is now finished. The spoiler log can be found here: {spoiler_log_url}")
+            self.state["random_settings_spoiler_log_unlocked"] = True
 
     async def ex_spoilerlogurl(self, args, message):
         spoiler_log_url = self.state.get("spoiler_log_url")
@@ -414,9 +417,8 @@ class RandoHandler(RaceHandler):
             await self.send_message("Seed rolled!")
         elif type == SeedType.RANDOM_SETTINGS:
             self.state["permalink"] = None
-
-            spoiler_log_url = generated_seed.get("spoiler_log_url")
-            self.state["spoiler_log_url"] = spoiler_log_url
+            self.state["spoiler_log_url"] = generated_seed.get("spoiler_log_url")
+            self.state["random_settings_seed_rolled"] = True
 
             await self.send_message(f"Seed: {permalink}")
             await self.send_message(f"Seed Hash: {seed_hash}")


### PR DESCRIPTION
This PR updates the bot to post a link to a Gist with the spoiler log for a random settings race after the race is finished.

The spoiler log of a random settings seed is only generated if it's run from source, meaning while others can generate spoiler logs if running from source, their seeds won't be the same as the race seed without the correct seed key.