### PR TITLE
Add secondary check for race finish

### DIFF
--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -158,10 +158,16 @@ class RandoHandler(RaceHandler):
 
             self.state["finished_entrants"] = finished_entrants
 
+        num_finished_entrants = sum(
+            entrant.get("status").get("value") in ("done", "dnf", "dq") for entrant in self.data.get("entrants")
+        )
         if (
             self.state.get("random_settings_spoiler_log_url") is not None
             and not self.state.get("random_settings_spoiler_log_unlocked")
-            and self.data.get("status").get("value") == "finished"
+            and (
+                self.data.get("status").get("value") == "finished"
+                or len(self.data.get("entrants")) == num_finished_entrants
+            )
         ):
             spoiler_log_url = self.state.get("random_settings_spoiler_log_url")
             await self.send_message(f"The race is now finished. The spoiler log can be found here: {spoiler_log_url}")


### PR DESCRIPTION
This PR adds a secondary check to determine whether a race is finished for random settings races. Previously, we only check if the race status was `"finished"`. Now, we also count the number of runners that are finished and check if this equals the total number of entrants. If either of these conditions are true, we consider the race to have finished.

This change was made in response to this race https://racetime.gg/twwr/dizzy-morth-2889 in which the spoiler log failed to be shared after the race finished.