### PR TITLE
Update RS version to v1.3.1

### DIFF
--- a/randobot/constants.py
+++ b/randobot/constants.py
@@ -55,8 +55,8 @@ DEV_VERSION = "1.9.10_dev"
 DEV_DOWNLOAD = "https://github.com/tanjo3/wwrando/releases"
 
 RS_PATH = "wwrando-random-settings"
-RS_VERSION = "v1.3"
-RS_DOWNLOAD = "https://github.com/tanjo3/wwrando/releases/tag/RS_v1.3"
+RS_VERSION = "v1.3.1"
+RS_DOWNLOAD = "https://github.com/tanjo3/wwrando/releases/tag/RS_v1.3.1"
 RS_TRACKER = "https://jaysc.github.io/tww-rando-tracker-rs/"
 
 S5_PERMALINKS = OrderedDict([


### PR DESCRIPTION
This PR updates the random settings version to v1.3.1, which mainly addresses an issue with seed hashes not matching up.