### PR TITLE
Fix S5 preset

### DIFF
--- a/randobot/constants.py
+++ b/randobot/constants.py
@@ -11,7 +11,7 @@ class SeedType(Enum):
 
 
 STANDARD_PERMALINKS = OrderedDict([
-    ("s5",        "MS4xMC4wAEEAFQMiAPOOwAMMsACCcQ8AAMkHAQAA"),
+    ("s5",        "MS4xMC4wAEEAFQMiAJPowAMMsACCcQ8AAMkHAQAA"),
     ("s4",        "MS4xMC4wAEEABQsiAAUAvgMcsAACAAAAAAGAIAAA"),
     ("beginner",  "MS4xMC4wAEEABQMCAHOGwAMMcADC+Q8AAskPKQAG"),
     ("co-op",     "MS4xMC4wAEEAFQsmANsMwQMcMAECAAAAAAGAAAAA"),


### PR DESCRIPTION
Fixes the S5 preset's hint distribution: 7 path/7 barren/4 location -> 4 path/4 barren/7 location