### PR TITLE
Miniblins Preset

### DIFF
--- a/randobot/constants.py
+++ b/randobot/constants.py
@@ -13,7 +13,7 @@ class SeedType(Enum):
 STANDARD_PERMALINKS = OrderedDict([
     ("s5",        "MS4xMC4wAEEAFQMiAJPowAMMsACCcQ8AAMkHAQAA"),
     ("s4",        "MS4xMC4wAEEABQsiAAUAvgMcsAACAAAAAAGAIAAA"),
-    ("beginner",  "MS4xMC4wAEEABQMCAHOGwAMMcADC+Q8AAskPKQAG"),
+    ("miniblins", "MS4xMC4wAEEABwMCAHOGwAMMcADC+Q8AAskPKQAG"),
     ("co-op",     "MS4xMC4wAEEAFQsmANsMwQMcMAGCcQ8AAMkHAAAA"),
     ("allsanity", "MS4xMC4wAEEA//9/gtsMwQMcUAECAAAAAAkAAAAA"),
     ("s3",        "MS4xMC4wAEEAFwMEAAQAvhMM8AADAAAAAAGAIAAA"),


### PR DESCRIPTION
This PR updates the `beginner` preset to be called `miniblins` and updates the permalink to match the settings used in the Miniblins tournament (old beginner preset + Great Fairies).