### PR TITLE
S6 Update

### DIFF
--- a/randobot/constants.py
+++ b/randobot/constants.py
@@ -10,6 +10,7 @@ class SeedType(Enum):
 
 
 STANDARD_PERMALINKS = OrderedDict([
+    ("s6",        "MS4xMC4wAEEAFwMiAHPowgMMsACCcQ8AAMkHAAAA"),
     ("s5",        "MS4xMC4wAEEAFQMiAJPowAMMsACCcQ8AAMkHAQAA"),
     ("s4",        "MS4xMC4wAEEABQsiAAUAvgMcsAACAAAAAAGAIAAA"),
     ("miniblins", "MS4xMC4wAEEABwMCAHOGwAMMcADC+Q8AAskPKQAG"),
@@ -18,7 +19,19 @@ STANDARD_PERMALINKS = OrderedDict([
     ("s3",        "MS4xMC4wAEEAFwMEAAQAvhMM8AADAAAAAAGAIAAA"),
 ])
 
-STANDARD_DEFAULT = ["s5"]
+RUNNER_AGREEMENTS = OrderedDict([
+    ("4drm",     "4-Dungeon Race Mode"),
+    ("nosword",  "No Starting Sword"),
+    ("der",      "Randomized Dungeon Entrances"),
+    ("keys",     "Key-Lunacy"),
+    ("tingle",   "Tingle Chests"),
+    ("expen",    "Expensive Purchases"),
+    ("subs",     "Submarines"),
+    ("minis",    "Minigames"),
+    ("combat",   "Combat Secret Caves"),
+])
+
+STANDARD_DEFAULT = ["s6"]
 STANDARD_PATH = "wwrando"
 
 SPOILER_LOG_PERMALINKS = OrderedDict([

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -232,7 +232,7 @@ class RandoHandler(RaceHandler):
             for ra, description in constants.RUNNER_AGREEMENTS.items()
         ])
         await self.send_message(msg)
-        
+
     @monitor_cmd
     async def ex_lock(self, args, message):
         self.state["locked"] = True
@@ -515,7 +515,7 @@ class RandoHandler(RaceHandler):
 
         # Raise exception if all settings are banned
         if len(permalink_args) + len(unbanned_presets) == 0:
-            msg = f"There were no valid settings to choose from after bans!"
+            msg = "There were no valid settings to choose from after bans!"
             await self.send_message(msg)
             raise Exception(msg)
 

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -567,8 +567,7 @@ class RandoHandler(RaceHandler):
             settings_key = permalink_args[settings_idx]
             preset_modifiers = []
         else:
-            settings_idx -= len(permalink_args)
-            settings_key, *preset_modifiers = parsed_presets[settings_idx]
+            settings_key, *preset_modifiers = valid_settings[settings_idx]
 
         # If a selection was made from more than one option or if selection is a S6 seed with runners' agreement
         # modifiers, update race room chat and info


### PR DESCRIPTION
This PR updates the bot for S6:

- Adds the permalink for the S6 Tournament as a preset and sets it as the default for the standard permalinks
- Adds the S6 set of runners' agreement (RA) modifiers
- Add static functions in the `Generator` class that handle updating permalinks with RA modifiers
- Update `choose_permalink` to handle rolling S6 seeds with RAs; an example of rolling a seed is `!rollseed s6+4drm+nosword`
- `choose_permalink` will also add the settings to the race room info when a S6+RA seed is rolled
- Also update logic `choose_permalink` to catch invalid arguments for S6+RA seeds, including making it case-insenstive to args (e.g., `!rollseed S6` and `!rollseed s6` should function identically) and printing more specific error messages
- Add the `!ra` command which will print a list of valid RA modifiers to the race room chat