### PR TITLE
random settings v1.4.0-dev3 build update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
             echo "${{ secrets.WWRANDO_SEED_KEY }}" > tww-rando-bot/wwrando/keys/seed_key.py
             echo "${{ secrets.WWRANDO_MP_SEED_KEY }}" > tww-rando-bot/wwrando-mixed-pools/keys/seed_key.py
             echo "${{ secrets.WWRANDO_DEV_TANJO3_SEED_KEY }}" > tww-rando-bot/wwrando-dev-tanjo3/keys/seed_key.py
-            echo "${{ secrets.WWRANDO_DEV_TANJO3_SEED_KEY }}" > tww-rando-bot/wwrando-random-settings/keys/seed_key.py
+            echo "${{ secrets.WWRANDO_RS_SEED_KEY }}" > tww-rando-bot/wwrando-random-settings/keys/seed_key.py
             cd tww-rando-bot
             docker-compose build --no-cache
             export GITHUB_TOKEN=${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
 	branch = dev-build-no-ui
 [submodule "wwrando-random-settings"]
 	path = wwrando-random-settings
-	url = https://github.com/wooferzfg/wwrando.git
-	branch = random-settings
+	url = https://github.com/Aelire/wwrando.git
+	branch = randobot-support
 [submodule "wwrando-mixed-pools"]
 	path = wwrando-mixed-pools
 	url = https://github.com/wooferzfg/wwrando.git

--- a/randobot/constants.py
+++ b/randobot/constants.py
@@ -81,13 +81,18 @@ MP_PATH = "wwrando-mixed-pools"
 MP_DOWNLOAD = "https://github.com/wooferzfg/wwrando/releases/tag/mixed-pools-build"
 
 RS_PATH = "wwrando-random-settings"
-RS_VERSION = "v1.3.1"
-RS_DOWNLOAD = "https://github.com/tanjo3/wwrando/releases/tag/RS_v1.3.1"
+RS_VERSION = "RS1.4.0-dev3"
+RS_DOWNLOAD = "https://github.com/Aelire/wwrando/releases/tag/RS1.4.0-dev3"
 RS_TRACKER = "https://jaysc.github.io/tww-rando-tracker-rs/"
+RS_DEFAULT = ["random-settings"]
+RS_PERMALINKS = OrderedDict([
+    ("random-settings", "UlMxLjQuMC1kZXYzAEEAgQU="),
+]
+)
 
 BANNABLE_PRESETS = SPOILER_LOG_DEFAULT
 
 MINIMUM_BREAK_DURATION = 5
 MINIMUM_BREAK_INTERVAL = 60
 
-PERMALINK_PREFIXES = ["MS4", "eJw"]
+PERMALINK_PREFIXES = ["MS4", "eJw", "UlM"]

--- a/randobot/generator.py
+++ b/randobot/generator.py
@@ -14,6 +14,7 @@ from github import Auth, Github, InputFileContent
 class ArgFormat(enum.Enum):
     V110 = '-noui -seed={seed_name} -permalink={permalink}'
     V111 = '--noui --dry --seed={seed_name} --permalink={permalink}'
+    RS14 = '--randobot --noui --dry --seed={seed_name} --permalink={permalink}'
 
 
 class Generator:

--- a/randobot/generator.py
+++ b/randobot/generator.py
@@ -1,4 +1,5 @@
 import base64
+import enum
 import os
 import random
 import re
@@ -10,23 +11,25 @@ import shortuuid
 from github import Auth, Github, InputFileContent
 
 
+class ArgFormat(enum.Enum):
+    V110 = '-noui -seed={seed_name} -permalink={permalink}'
+    V111 = '--noui --dry --seed={seed_name} --permalink={permalink}'
+
+
 class Generator:
     def __init__(self, github_token):
         self.github_token = github_token
 
-    def generate_seed(self, randomizer_path, permalink, username, generate_spoiler_log, new_args_format=False):
+    def generate_seed(self, randomizer_path, permalink, username, generate_spoiler_log,
+                      args_format: ArgFormat = ArgFormat.V110):
         trimmed_name = re.sub(r'\W+', '', username)[:12]
         random_suffix = shortuuid.ShortUUID().random(length=10)
         seed_name = f"{trimmed_name}{random_suffix}"
         file_name = "".join(random.choice(string.digits) for _ in range(6))
 
-        if new_args_format:
-            args = f"--noui --dry --seed={seed_name} --permalink={permalink}"
-        else:
-            args = f"-noui -seed={seed_name} -permalink={permalink}"
-
         os.system(
-            f"/venv/{randomizer_path}/bin/python {randomizer_path}/wwrando.py {args}"
+            f"/venv/{randomizer_path}/bin/python {randomizer_path}/wwrando.py " +
+            args_format.value.format(seed_name=seed_name, permalink=permalink)
         )
 
         permalink_file_name = f"permalink_{seed_name}.txt"

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -375,9 +375,22 @@ class RandoHandler(RaceHandler):
 
         await self.send_message("Rolling seed...")
 
+        settings_permalink = await self.choose_permalink(
+            constants.RS_DEFAULT,
+            constants.RS_PERMALINKS,
+            args
+        )
+
         username = message.get('user', {}).get('name')
-        generated_seed = await self._generate_seed(constants.RS_PATH, username, username, True)
-        await self.update_race_room_with_generated_seed(None, generated_seed, SeedType.RANDOM_SETTINGS)
+        generated_seed = await self._generate_seed(
+            constants.RS_PATH,
+            settings_permalink,
+            username,
+            generate_spoiler_log=True,
+            args_format=ArgFormat.RS14,
+        )
+
+        await self.update_race_room_with_generated_seed(settings_permalink, generated_seed, SeedType.RANDOM_SETTINGS)
 
         await self.send_message(
             f"Please note that this seed uses the Random Settings {constants.RS_VERSION} build of the randomizer. "
@@ -443,18 +456,10 @@ class RandoHandler(RaceHandler):
             self.state["file_name"] = file_name
 
             await self.send_message("Seed rolled!")
-        elif type == SeedType.RANDOM_SETTINGS:
-            self.state["permalink"] = None
-            self.state["random_settings_spoiler_log_url"] = generated_seed.get("spoiler_log_url")
-            self.state["random_settings_seed_rolled"] = True
-
-            await self.send_message(f"Seed: {permalink}")
-            await self.send_message(f"Seed Hash: {seed_hash}")
-
-            race_info = f"Seed: {permalink} | Seed Hash: {seed_hash}"
-            await self.set_raceinfo(race_info, False, False)
         else:
             self.state["permalink_available"] = True
+            if type == SeedType.RANDOM_SETTINGS:
+                self.state["random_settings_spoiler_log_url"] = generated_seed.get("spoiler_log_url")
 
             await self.send_message(f"Permalink: {permalink}")
             await self.send_message(f"Seed Hash: {seed_hash}")

--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -7,7 +7,7 @@ from racetime_bot import RaceHandler, can_monitor, monitor_cmd
 
 import randobot.constants as constants
 from randobot.constants import SeedType
-from randobot.generator import Generator
+from randobot.generator import ArgFormat, Generator
 
 
 class RandoHandler(RaceHandler):
@@ -361,7 +361,7 @@ class RandoHandler(RaceHandler):
             settings_permalink,
             username,
             generate_spoiler_log=False,
-            new_args_format=True,
+            args_format=ArgFormat.V111,
         )
         await self.update_race_room_with_generated_seed(settings_permalink, generated_seed, SeedType.STANDARD)
         await self.print_mixed_pools_build()
@@ -510,7 +510,7 @@ class RandoHandler(RaceHandler):
             settings_permalink,
             username,
             generate_spoiler_log=True,
-            new_args_format=True,
+            args_format=ArgFormat.V111,
         )
         await self.update_race_room_with_generated_seed(settings_permalink, generated_seed, SeedType.SPOILER_LOG)
         await self.print_mixed_pools_build()

--- a/randobot/tests/test_handler.py
+++ b/randobot/tests/test_handler.py
@@ -636,7 +636,7 @@ class TestHandler(unittest.IsolatedAsyncioTestCase):
             ),
         ])
 
-        self.assertEqual(state["example_permalink"],"UlMxLjQuMC1kZXYzAEEAgQU=")
+        self.assertEqual(state["example_permalink"], "UlMxLjQuMC1kZXYzAEEAgQU=")
         self.assertEqual(state["permalink"], "PERMA_UlMxLjQuMC1kZXYzAEEAgQU=")
         self.assertEqual(state["random_settings_spoiler_log_url"], "SPOILER_LOG_URL")
         self.assertEqual(state["random_settings_spoiler_log_unlocked"], False)

--- a/randobot/tests/test_handler.py
+++ b/randobot/tests/test_handler.py
@@ -2,6 +2,7 @@ import asyncio
 import unittest
 from unittest.mock import call, patch
 
+from randobot.generator import ArgFormat
 from randobot.handler import RandoHandler
 
 
@@ -10,7 +11,7 @@ class MockGenerator():
         raise Exception("Method not properly mocked")
 
 
-def mock_generate_seed_standard(randomizer_path, permalink, username, generate_spoiler_log, new_args_format=False):
+def mock_generate_seed_standard(randomizer_path, permalink, username, generate_spoiler_log, args_format=ArgFormat.V110):
     return {
         "file_name": "FILENAME",
         "permalink": f"PERMA_{permalink}",
@@ -19,7 +20,8 @@ def mock_generate_seed_standard(randomizer_path, permalink, username, generate_s
     }
 
 
-def mock_generate_seed_spoiler_log(randomizer_path, permalink, username, generate_spoiler_log, new_args_format=False):
+def mock_generate_seed_spoiler_log(randomizer_path, permalink, username, generate_spoiler_log,
+                                   args_format=ArgFormat.V110):
     if not generate_spoiler_log:
         raise Exception("Did not generate spoiler log")
 
@@ -411,7 +413,7 @@ class TestHandler(unittest.IsolatedAsyncioTestCase):
                 "MS4xMC4wXzVmMWJhZTYAQQDfsGDs4E8ExPETjHsAAEg+AAAAIA==",
                 "test_user",
                 generate_spoiler_log=False,
-                new_args_format=True,
+                args_format=ArgFormat.V111,
             ),
         ])
 
@@ -448,7 +450,7 @@ class TestHandler(unittest.IsolatedAsyncioTestCase):
                 "MS4xMC4wXzVmMWJhZTYAQQBNMEBMAEAEEvETzn8AEEh+SAEAIw==",
                 "test_user",
                 generate_spoiler_log=False,
-                new_args_format=True,
+                args_format=ArgFormat.V111,
             ),
         ])
 
@@ -581,7 +583,7 @@ class TestHandler(unittest.IsolatedAsyncioTestCase):
                 "MS4xMC4wXzVmMWJhZTYAQQDfsGDs4E8ExPETjHsAAEg+AAAAAA==",
                 "test_user",
                 generate_spoiler_log=True,
-                new_args_format=True,
+                args_format=ArgFormat.V111,
             ),
         ])
 


### PR DESCRIPTION
This adds support for an updated build of random settings, replacing the existing 1.9-based random settings build. This has a different interface and looks much more like a standard rando with a permalink too, so there are a few changes to go along with bumping the link and version

I plan to put in randobot support directly into the official release when it gets there, so it requires a slightly different set of command-line options from either 1.10 or mixed pools. There's a preparatory commit to handle that

This points the git submodule into my repo for now but we can integrate it into your wwrando repo if you prefer and point to that