### PR TITLE
Fix S8 permalinks

### DIFF
--- a/randobot/constants.py
+++ b/randobot/constants.py
@@ -46,14 +46,14 @@ DEFAULT_PLANNING_TIME = 60
 MINIMUM_PLANNING_TIME = 20
 
 S8_PERMALINKS = OrderedDict([
-    ("s8",          "eJwLtlAIyS8tykvMTc0rUSgzZHBkuPu5iKPBmEHAwZEBCBqAqJ9RAMSUYLJzrjf4KL/hf7YJAxjc8WjgcHlyWt3GVp5BwOMfE1CNA4MIgytjhQYXAGYwFsk="),  # noqa: E501
-    ("mixed-pools", "eJwLtlAIyS8tykvMTc0rUSgzZHBkuL8hgYFIsObgfI4O5SPqBhbSDAweb0BCDlApDgDi7A15"),
+    ("s8",          "eJwLtlAIyS8tykvMTc0rUSgzjDdJMTc3szRlcGS4+7mIo8GYQcDBkQEIGoCon1EAxJRgsnOuN/gov+F/tgkDGNzxaOBweXJa3cZWnkHA4x8TUI0DgwiDK2OFBhcAM80Y0g=="),  # noqa: E501
+    ("mixed-pools", "eJwLtlAIyS8tykvMTc0rUSgzjDdJMTc3szRl8M2sSE0JyM/PKfYqzUs1dGK4vyGBgUjw5uB8jo7kA+o2tvIMAh7/mIBCDlApDgAIyxX/"),  # noqa: E501
 ])
 S8_DEFAULT = ["s8"]
 
 S8_SL_PERMALINKS = OrderedDict([
-    ("s8-sl",          "eJwLtlAIyS8tykvMTc0rUSgzZHBkuPu5iKPBmEHAwZEBCBqAqJ9RAMSUYLJzrjf4KL/hf7YJAxjc8WjgcHlyWt3GVp5BwOMfE1CNA4MIgytjhQYTAGYoFsE="),  # noqa: E501
-    ("mixed-pools-sl", "eJwLtlAIyS8tykvMTc0rUSgzZHBkuL8hgYFIsObgfI4O5SPqBhbSDAweb0BCDjA5AOLkDXE="),
+    ("s8-sl",          "eJwLtlAIyS8tykvMTc0rUSgzjDdJMTc3szRlcGS4+7mIo8GYQcDBkQEIGoCon1EAxJRgsnOuN/gov+F/tgkDGNzxaOBweXJa3cZWnkHA4x8TUI0DgwiDK2OFBhMAM8UYyg=="),  # noqa: E501
+    ("mixed-pools-sl", "eJwLtlAIyS8tykvMTc0rUSgzjDdJMTc3szRl8M2sSE0JyM/PKfYqzUs1dGK4vyGBgUjw5uB8jo7kA+o2tvIMAh7/mIBCDjA5AAjDFfc="),  # noqa: E501
 ])
 S8_SL_DEFAULT = ["s8-sl"]
 

--- a/randobot/tests/test_handler.py
+++ b/randobot/tests/test_handler.py
@@ -76,7 +76,7 @@ class TestHandler(unittest.IsolatedAsyncioTestCase):
         await handler.ex_s8([], get_mock_message_data())
 
         self.assertEqual(mock_send_message.call_count, 6)
-        permalink = "eJwLtlAIyS8tykvMTc0rUSgzZHBkuPu5iKPBmEHAwZEBCBqAqJ9RAMSUYLJzrjf4KL/hf7YJAxjc8WjgcHlyWt3GVp5BwOMfE1CNA4MIgytjhQYXAGYwFsk="  # noqa: E501
+        permalink = "eJwLtlAIyS8tykvMTc0rUSgzjDdJMTc3szRlcGS4+7mIo8GYQcDBkQEIGoCon1EAxJRgsnOuN/gov+F/tgkDGNzxaOBweXJa3cZWnkHA4x8TUI0DgwiDK2OFBhcAM80Y0g=="  # noqa: E501
         mock_send_message.assert_has_calls([
             call("Rolling seed..."),
             call(f"Permalink: PERMA_{permalink}"),
@@ -386,7 +386,7 @@ class TestHandler(unittest.IsolatedAsyncioTestCase):
         await wait_for_all_async_tasks()
 
         self.assertEqual(mock_send_message.call_count, 15)
-        permalink = "eJwLtlAIyS8tykvMTc0rUSgzZHBkuPu5iKPBmEHAwZEBCBqAqJ9RAMSUYLJzrjf4KL/hf7YJAxjc8WjgcHlyWt3GVp5BwOMfE1CNA4MIgytjhQYTAGYoFsE="  # noqa: E501
+        permalink = "eJwLtlAIyS8tykvMTc0rUSgzjDdJMTc3szRlcGS4+7mIo8GYQcDBkQEIGoCon1EAxJRgsnOuN/gov+F/tgkDGNzxaOBweXJa3cZWnkHA4x8TUI0DgwiDK2OFBhMAM8UYyg=="  # noqa: E501
         mock_send_message.assert_has_calls([
             call("Rolling seed..."),
             call("Seed rolled!"),


### PR DESCRIPTION
This PR fixes the permalinks that use the S8 build. I used the version of the randomizer that doesn't include the git commit tag to generate the old ones. The new ones were generated using the release build.